### PR TITLE
Specify ubuntu-22.04 instead of latest

### DIFF
--- a/.github/workflows/build_dotnet_publish_nuget.yml
+++ b/.github/workflows/build_dotnet_publish_nuget.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       build-suffix: ${{ steps.setup-build.outputs.build-suffix }}
     steps:
@@ -25,7 +25,7 @@ jobs:
         run: echo "build-suffix=${{ github.event_name == 'push' && env.CiRunPushSuffix || github.event_name == 'pull_request' && env.CiRunPullSuffix || null }}" >> "$GITHUB_OUTPUT"
 
   check-semver:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'release'
     steps:
       - name: Checkout current version
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         configuration: [debug, release]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         include:
           - os: windows-latest
             configuration: release
@@ -119,7 +119,7 @@ jobs:
           path: artifacts/package/${{matrix.configuration}}/**
 
   publish-github:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
     needs: [build]
@@ -144,7 +144,7 @@ jobs:
 
   deploy:
     name: Deploy Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build]
     if: github.event_name == 'release' && always() && !failure() && !cancelled()
 


### PR DESCRIPTION
Due to numerous changes to the image for Ubuntu 24 (soon to be ubuntu-latest), this change ensures that we maintain compatibility and functionality by pinning to Ubuntu 22.04